### PR TITLE
Update computersearch.py

### DIFF
--- a/computersearch.py
+++ b/computersearch.py
@@ -16,7 +16,7 @@ class ComputerSearch:
         if self._ldapConnection.bind() == False:
             raise Exception("LDAP login failed")
             
-        self._base = server.info.naming_contexts[0]
+        self._base = server.info.naming_contexts[2]
         
      
     def find_linux_hosts(self):


### PR DESCRIPTION
Changed the value to fetch via server.info.naming_contexts[0] to server.info.naming_contexts[2].
If you are working with a forest, 0 will give back the naming context of the root domain, rather than the one you are targeting.
Selecting [2] refers to the domain specified and makes it work.